### PR TITLE
Add repository input to the action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   commitish:
     description: 'Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit'
     required: false
+  repository:
+    description: 'owner/repo path to change where the release is created'
+    required: false
 outputs:
   id:
     description: 'The ID of the created Release'


### PR DESCRIPTION
That way the actions don't show warning/errors.

@erezrokah 