### PR TITLE
chore: remove commitish input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,6 @@ inputs:
     description: '`true` to identify the release as a prerelease. `false` to identify the release as a full release. Default: `false`'
     required: false
     default: false
-  commitish:
-    description: 'Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit'
-    required: false
   repository:
     description: 'owner/repo path to change where the release is created'
     required: false


### PR DESCRIPTION
This functionality was removed in https://github.com/netlify-labs/create-release/commit/ea4b6282cdf49956d4b077b2f0a6356dc9f99cd2