### PR TITLE
fix: actions tagger warning

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: Actions-R-Us/actions-tagger@latest
         with:
-          publish_latest: true
+          publish_latest_tag: true
         env:
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'


### PR DESCRIPTION
Replaces a deprecated input name (https://github.com/netlify-labs/create-release/runs/1060987478?check_suite_focus=true#step:2:1)